### PR TITLE
feature: customize endpoint.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/opentsdb/protocols/http_connect.py
+++ b/opentsdb/protocols/http_connect.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import gzip
+import os.path
 from typing import Optional
 
 from requests import Session
@@ -12,33 +13,30 @@ logger = logging.getLogger('opentsdb-py')
 
 
 class TSDBUrls:
-    VERSION_ENDPOINT = '/api/version'
-    PUT_ENDPOINT = '/api/put?details=true'
 
-    def __init__(self, base_url):
-        self.version = base_url + self.VERSION_ENDPOINT
-        self.put = base_url + self.PUT_ENDPOINT
+    def __init__(self, base_url, version_endpoint, put_endpoint):
+        self.version = base_url + version_endpoint
+        self.put = base_url + put_endpoint
 
     @classmethod
-    def from_host_and_port(cls, host, port):
+    def from_host_and_port(cls, host, port, version_endpoint, put_endpoint):
         base_url = 'http://{}:{}'.format(host, port)
-        return cls(base_url)
+        return cls(base_url, version_endpoint, put_endpoint)
 
     @classmethod
-    def from_uri(cls, uri):
-        return cls(uri)
+    def from_uri(cls, uri, version_endpoint, put_endpoint):
+        return cls(uri, version_endpoint, put_endpoint)
 
 
 class HttpTSDBConnect(TSDBConnect):
-
     SEND_TIMEOUT = 2
 
     def __init__(self, host: str, port: int, check_tsdb_alive: bool,
-                 compression: str, uri: Optional[str]):
+                 compression: str, version_endpoint: str, put_endpoint: str, uri: Optional[str]):
         if uri is None:
-            self.tsdb_urls = TSDBUrls.from_host_and_port(host, int(port))
+            self.tsdb_urls = TSDBUrls.from_host_and_port(host, int(port), version_endpoint, put_endpoint)
         else:
-            self.tsdb_urls = TSDBUrls.from_uri(uri)
+            self.tsdb_urls = TSDBUrls.from_uri(uri, version_endpoint, put_endpoint)
         super().__init__(host, port, check_tsdb_alive)
         self.compression = compression
         assert self.compression in ['gzip', None], 'Unsupported HTTP compression type: %s' % self.compression

--- a/opentsdb/protocols/tests/test_http_urls.py
+++ b/opentsdb/protocols/tests/test_http_urls.py
@@ -1,12 +1,13 @@
-
 from opentsdb.protocols.http_connect import TSDBUrls
 
 
 def test_from_host_port():
-    url = TSDBUrls.from_host_and_port('127.0.0.1', 4242)
-    assert url.version == 'http://127.0.0.1:4242' + TSDBUrls.VERSION_ENDPOINT
+    url = TSDBUrls.from_host_and_port('127.0.0.1', 4242, version_endpoint="/api/version",
+                                      put_endpoint="/api/put?details=true")
+    assert url.put == 'http://127.0.0.1:4242/api/put?details=true'
 
 
 def test_from_uri():
-    url = TSDBUrls.from_uri('https://127.0.0.1:4242/opentsdb')
-    assert url.version == 'https://127.0.0.1:4242/opentsdb' + TSDBUrls.VERSION_ENDPOINT
+    url = TSDBUrls.from_uri('https://127.0.0.1:4242/opentsdb', version_endpoint="/api/version",
+                            put_endpoint="/api/put?details=true")
+    assert url.version == 'https://127.0.0.1:4242/opentsdb/api/version'

--- a/opentsdb/tsdb_client.py
+++ b/opentsdb/tsdb_client.py
@@ -18,6 +18,8 @@ class TSDBClient:
     TSDB_HOST = environ.get('OPEN_TSDB_HOST', '127.0.0.1')
     TSDB_PORT = int(environ.get('OPEN_TSDB_PORT', 4242))
     TSDB_URI = environ.get('OPEN_TSDB_URI')
+    TSDB_PUT_ENDPOINT = environ.get('OPEN_TSDB_PUT_ENDPOINT', '/api/put?details=true')
+    TSDB_VERSION_ENDPOINT = environ.get('OPEN_TSDB_VERSION_ENDPOINT', '/api/version')
 
     TSDB_MAX_METRICS_QUEUE_SIZE = int(environ.get('TSDB_MAX_METRICS_QUEUE_SIZE', 10000))
     TSDB_SEND_METRICS_PER_SECOND_LIMIT = int(environ.get('TSDB_SEND_METRICS_PER_SECOND_LIMIT', 1000))
@@ -25,19 +27,23 @@ class TSDBClient:
     TSDB_DEFAULT_HTTP_COMPRESSION = environ.get('TSDB_DEFAULT_HTTP_COMPRESSION', 'gzip')
     VALID_METRICS_CHARS = set(string.ascii_letters + string.digits + '-_./')
 
-    def __init__(self,
-                 host: str=TSDB_HOST,
-                 port: int=TSDB_PORT,
-                 check_tsdb_alive: bool=False,
-                 protocol: str=TSDBConnectProtocols.HTTP,
-                 run_at_once: bool=True,
-                 static_tags: dict=None,
-                 host_tag: bool=True,
-                 max_queue_size: int=TSDB_MAX_METRICS_QUEUE_SIZE,
-                 http_compression: str=TSDB_DEFAULT_HTTP_COMPRESSION,
-                 uri: str=TSDB_URI,
-                 send_metrics_limit: int=TSDB_SEND_METRICS_PER_SECOND_LIMIT,
-                 send_metrics_batch_limit: int=TSDB_SEND_METRICS_BATCH_LIMIT):
+    def __init__(
+            self,
+            host: str = TSDB_HOST,
+            port: int = TSDB_PORT,
+            check_tsdb_alive: bool = False,
+            protocol: str = TSDBConnectProtocols.HTTP,
+            run_at_once: bool = True,
+            static_tags: dict = None,
+            host_tag: bool = True,
+            max_queue_size: int = TSDB_MAX_METRICS_QUEUE_SIZE,
+            http_compression: str = TSDB_DEFAULT_HTTP_COMPRESSION,
+            uri: str = TSDB_URI,
+            send_metrics_limit: int = TSDB_SEND_METRICS_PER_SECOND_LIMIT,
+            send_metrics_batch_limit: int = TSDB_SEND_METRICS_BATCH_LIMIT,
+            put_endpoint: str = TSDB_PUT_ENDPOINT,
+            version_endpoint: str = TSDB_VERSION_ENDPOINT,
+    ):
 
         self.host_tag = host_tag
         self.protocol = protocol
@@ -55,12 +61,17 @@ class TSDBClient:
         self._metric_send_thread = None
 
         if run_at_once is True:
-            self.init_client(host, port, uri)
+            self.init_client(host, port, uri, put_endpoint, version_endpoint)
 
-    def init_client(self, host, port: int=TSDB_PORT, uri: Optional[str]=None):
+    def init_client(
+            self, host, port: int = TSDB_PORT, uri: Optional[str] = None,
+            put_endpoint: str = TSDB_PUT_ENDPOINT,
+            version_endpoint: str = TSDB_VERSION_ENDPOINT
+    ):
         self._tsdb_connect = TSDBConnectProtocols.get_connect(
             self.protocol, host, port, self.check_tsdb_alive,
-            compression=self.http_compression, uri=uri
+            compression=self.http_compression, uri=uri,
+            put_endpoint=put_endpoint, version_endpoint=version_endpoint
         )
 
         self._metric_send_thread = TSDBConnectProtocols.get_push_thread(


### PR DESCRIPTION
[Nightingale](https://github.com/ccfos/nightingale) need an endpoint `/opentsdb/put` instead of default endpoint `/api/put`.